### PR TITLE
apply jdk24 and maintenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           echo $ {{github.event.pull_request.state }}
           echo $ {{github.event.pull_request.opened }}
-          gradle build --no-daemon --stacktrace --parallel
+          gradle build --stacktrace --parallel
 
       - name: "Zip build reports"
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: 'graalvm jdk21 setup'
         uses: graalvm/setup-graalvm@v1
         with:
-          java-version: '21'
+          java-version: '24'
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,10 @@ jobs:
           distribution: 'graalvm'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           native-image-job-reports: 'true'
-          cache: 'gradle'
+          cache: ''
+      # Gradle 캐싱 및 환경 설정
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
 
       - name: 'gradle build'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           echo $ {{github.event.pull_request.state }}
           echo $ {{github.event.pull_request.opened }}
-          gradle build --stacktrace --parallel
+          ./gradlew build --stacktrace --parallel
 
       - name: "Zip build reports"
         if: failure()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+
 plugins {
     java
     id("org.springframework.boot") version "3.5.3"
@@ -15,7 +16,8 @@ plugins {
 }
 group = "dev.haja"
 var releaseVer = "v0.0.1"
-version = "$releaseVer-${LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"))}"
+version =
+    "$releaseVer-${LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"))}"
 
 java {
     toolchain { languageVersion = JavaLanguageVersion.of(24) }
@@ -73,8 +75,6 @@ dependencies {
 
     // dev only
     developmentOnly("org.springframework.boot:spring-boot-devtools")
-
-
 
 }
 hibernate {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,7 +84,7 @@ hibernate {
 }
 
 tasks.withType<JavaCompile> {
-    options.compilerArgs.add("-Xlint:deprecation")
+    options.compilerArgs.add("-Xlint:unchecked")
     options.encoding = "UTF-8"
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,8 +18,8 @@ var releaseVer = "v0.0.1"
 version = "$releaseVer-${LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"))}"
 
 java {
-    toolchain { languageVersion = JavaLanguageVersion.of(21) }
-    sourceCompatibility = JavaVersion.VERSION_21
+    toolchain { languageVersion = JavaLanguageVersion.of(24) }
+    sourceCompatibility = JavaVersion.VERSION_24
 }
 
 configurations {
@@ -106,7 +106,7 @@ tasks.named("processTestAot").configure {
 
 tasks.withType<KotlinCompile> {
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_21)
+        jvmTarget.set(JvmTarget.JVM_24)
         languageVersion.set(KotlinVersion.KOTLIN_2_1)
         apiVersion.set(KotlinVersion.KOTLIN_2_1)
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,10 +58,10 @@ dependencies {
     testAnnotationProcessor("org.mapstruct:mapstruct-processor:1.6.3")
 
     // Lombok
-    compileOnly("org.projectlombok:lombok:1.18.38")
-    testCompileOnly("org.projectlombok:lombok:1.18.38")
-    annotationProcessor("org.projectlombok:lombok:1.18.38")
-    testAnnotationProcessor("org.projectlombok:lombok:1.18.38")
+    compileOnly("org.projectlombok:lombok")
+    testCompileOnly("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok")
+    testAnnotationProcessor("org.projectlombok:lombok")
 
     // Lombok과 MapStruct 통합
     annotationProcessor("org.projectlombok:lombok-mapstruct-binding:0.2.0")
@@ -107,8 +107,8 @@ tasks.named("processTestAot").configure {
 tasks.withType<KotlinCompile> {
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_24)
-        languageVersion.set(KotlinVersion.KOTLIN_2_1)
-        apiVersion.set(KotlinVersion.KOTLIN_2_1)
+        languageVersion.set(KotlinVersion.KOTLIN_2_2)
+        apiVersion.set(KotlinVersion.KOTLIN_2_2)
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,6 +85,7 @@ hibernate {
 
 tasks.withType<JavaCompile> {
     options.compilerArgs.add("-Xlint:unchecked")
+    options.compilerArgs.add("-Xlint:-unchecked") // AOT 생성 코드의 unchecked 경고 무시
     options.encoding = "UTF-8"
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,9 +9,9 @@ plugins {
     id("io.spring.dependency-management") version "1.1.7"
     id("org.hibernate.orm") version "6.6.18.Final"
     id("org.graalvm.buildtools.native") version "0.10.6"
-    kotlin("jvm") version "2.1.21"
-    kotlin("plugin.spring") version "2.1.21"
-    kotlin("plugin.jpa") version "2.1.21"
+    kotlin("jvm") version "2.2.0"
+    kotlin("plugin.spring") version "2.2.0"
+    kotlin("plugin.jpa") version "2.2.0"
 }
 group = "dev.haja"
 var releaseVer = "v0.0.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/test/java/dev/haja/buckpal/SendMoneySystemTest.java
+++ b/src/test/java/dev/haja/buckpal/SendMoneySystemTest.java
@@ -23,9 +23,10 @@ import static org.assertj.core.api.BDDAssertions.then;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class SendMoneySystemTest {
 
-    @Autowired
+    @Autowired 
     private TestRestTemplate restTemplate;
-    @Autowired
+    
+    @Autowired 
     private LoadAccountPort loadAccountPort;
 
     @Test

--- a/src/test/java/dev/haja/buckpal/account/adapter/in/web/SendMoneyControllerTest.java
+++ b/src/test/java/dev/haja/buckpal/account/adapter/in/web/SendMoneyControllerTest.java
@@ -84,6 +84,7 @@ class SendMoneyControllerTest {
     @Test
     void testSendMoneyValidationFailure_NegativeAmount() throws Exception {
         // given
+        @SuppressWarnings("ConstantConditions") // 의도적으로 음수 값을 사용하여 유효성 검사 실패를 테스트
         SendMoneyReqDto requestDto = new SendMoneyReqDto(1L, 2L, -500L);
         
         // when & then

--- a/src/test/java/dev/haja/buckpal/account/adapter/in/web/SendMoneyControllerTest.java
+++ b/src/test/java/dev/haja/buckpal/account/adapter/in/web/SendMoneyControllerTest.java
@@ -13,8 +13,8 @@ import dev.haja.buckpal.account.domain.Money;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import static org.mockito.BDDMockito.willReturn;
@@ -27,7 +27,7 @@ class SendMoneyControllerTest {
     
     @Autowired private ObjectMapper objectMapper;
     
-    @MockBean private SendMoneyUseCase sendMoneyUseCase;
+    @MockitoBean private SendMoneyUseCase sendMoneyUseCase;
 
     @Test
     void testSendMoney() throws Exception {


### PR DESCRIPTION
close #22

## Sourcery 요약

JDK 24를 대상으로 유지 관리 업그레이드를 적용하고, Kotlin 및 Gradle 버전을 업데이트하며, 테스트 어노테이션 및 경고를 개선합니다.

개선 사항:
- Java toolchain, 소스 호환성 및 Kotlin JVM 대상을 JDK 24로 업그레이드
- Kotlin 플러그인 버전을 2.2.0으로 업데이트
- Gradle wrapper를 8.14.3으로 업데이트

테스트:
- SendMoneyControllerTest에서 @MockBean을 @MockitoBean으로 대체
- 음수 금액 유효성 검사 테스트에서 상수 조건 경고를 억제

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Apply maintenance upgrades by targeting JDK 24, updating Kotlin and Gradle versions, and refining test annotations and warnings

Enhancements:
- Upgrade Java toolchain, source compatibility, and Kotlin JVM target to JDK 24
- Bump Kotlin plugin versions to 2.2.0
- Update Gradle wrapper to 8.14.3

Tests:
- Replace @MockBean with @MockitoBean in SendMoneyControllerTest
- Suppress constant condition warning in negative amount validation test

</details>