### PR TITLE
24 maintain250730

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,127 @@
+# CLAUDE.md
+
+이 파일은 이 저장소에서 코드를 작업할 때 Claude Code(claude.ai/code)에 대한 지침을 제공합니다.
+
+## Build and Development Commands
+
+이것은 Gradle과 Kotlin DSL을 사용한 Spring Boot 애플리케이션입니다.
+
+### Build Commands
+- `./gradlew build` - Build the entire project
+- `./gradlew assemble` - Build without running tests
+- `./gradlew clean` - Clean build artifacts
+- `./gradlew bootJar` - Create executable JAR
+
+### Running the Application
+- `./gradlew bootRun` - Run the Spring Boot application
+- `./gradlew bootTestRun` - Run using test runtime classpath
+
+### Testing
+- `./gradlew test` - Run all tests (uses JUnit 5 Platform)
+- `./gradlew nativeTest` - Run tests as native binary
+- Tests run in parallel using all available processors
+- Architecture tests validate hexagonal architecture compliance using ArchUnit
+
+## Architecture Overview
+
+This project implements **Hexagonal Architecture** (Clean Architecture) for a banking application called "BuckPal". The architecture enforces strict separation of concerns with the following layers:
+
+### Core Structure
+```
+src/main/java/dev/haja/buckpal/
+├── account/                    # Main business domain
+│   ├── domain/                # Domain entities and business logic
+│   │   ├── Account.java       # Core account entity with business rules
+│   │   ├── Activity.java      # Account activity/transaction entity
+│   │   ├── ActivityWindow.java # Collection of activities
+│   │   └── Money.java         # Value object for monetary amounts
+│   ├── application/           # Application services and ports
+│   │   ├── port/
+│   │   │   ├── in/           # Inbound ports (use cases)
+│   │   │   └── out/          # Outbound ports (repositories)
+│   │   └── service/          # Application services implementing use cases
+│   └── adapter/              # External adapters
+│       ├── in/web/          # Web controllers (REST APIs)
+│       └── out/persistence/ # Database persistence adapters
+└── common/                   # Shared infrastructure annotations
+```
+
+### Architectural Rules (Enforced by Tests)
+- **Domain Layer**: Contains pure business logic, no dependencies on other layers
+- **Application Layer**: Orchestrates business flows, depends only on domain
+- **Adapter Layer**: Handles external communication (web, database)
+- Ports define contracts between layers
+- Dependency direction: Adapters → Application → Domain
+
+### Key Design Patterns
+- **Ports and Adapters**: Clear interface contracts between layers  
+- **Factory Methods**: Domain entities use static factory methods (e.g., `Account.withId()`, `Account.withoutId()`)
+- **Value Objects**: `Money`, `AccountId` are immutable value objects
+- **Command Pattern**: Operations like `SendMoneyCommand` encapsulate requests
+- **Repository Pattern**: Data access through port interfaces
+
+## Technology Stack
+
+### Core Technologies
+- **Java 24** with **Kotlin 2.2** (mixed language project)
+- **Spring Boot 3.5.4** (Web, JPA, Validation, Actuator)
+- **Spring Data JPA** with Hibernate 6.6.22.Final
+- **H2 Database** (runtime and testing)
+
+### Development Tools
+- **Lombok** - Reduces boilerplate code with Kotlin plugin support
+- **MapStruct 1.6.3** - Type-safe bean mapping
+- **Lombok-MapStruct binding** - Integration between Lombok and MapStruct
+- **Kassava 2.1.0** - Kotlin data class utilities
+- **ArchUnit 1.4.1** - Architecture testing framework
+- **GraalVM Native Image** support
+
+### Code Quality
+- **Kotlin strict null safety** enabled (`-Xjsr305=strict`)
+- **All warnings as errors** in Kotlin compilation
+- **ArchUnit tests** enforce architectural boundaries
+- **JPA entities** automatically opened for proxy creation
+
+## Project Configuration
+
+### Database
+- Development: H2 in-memory database
+- JPA DDL: `create-drop` (recreates schema on startup)
+- Hibernate SQL logging enabled in debug mode
+
+### Application Profiles
+- Default active profile: `local`
+- Application name: "Get-your-hands-dirty-on-clean-architecture"
+
+## Testing Strategy
+
+### Test Structure
+- **Unit Tests**: Test individual components in isolation
+- **Integration Tests**: Test adapter integrations (e.g., `AccountPersistenceAdapterTest`)
+- **System Tests**: End-to-end testing (`SendMoneySystemTest`) 
+- **Architecture Tests**: Validate hexagonal architecture rules (`DependencyRuleTests`)
+
+### Key Test Classes
+- Architecture compliance verified in `DependencyRuleTests.java:24`
+- System-level money transfer tested in `SendMoneySystemTest`
+- Domain logic tested in `AccountTest`, `ActivityWindowTest`
+
+## Important Implementation Notes
+
+### Domain Model
+- `Account` entities track balance through baseline + activity window calculation
+- Business rules (e.g., withdrawal limits) are enforced in domain entities
+- Money transfers require locking both source and target accounts
+- All monetary operations use the `Money` value object for type safety
+
+### Persistence Strategy  
+- JPA entities (`AccountJpaEntity`, `ActivityJpaEntity`) separate from domain entities
+- `AccountMapper` handles conversion between JPA and domain entities
+- Account locking mechanism (`AccountLock`) prevents concurrent modification
+
+### Error Handling
+- `ThresholdExceededException` for transfer limit violations
+- Domain validation through `SelfValidating` base class
+- Proper error messages with account descriptions
+
+The codebase demonstrates clean architecture principles with clear separation between business logic, application orchestration, and infrastructure concerns.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
     id("io.spring.dependency-management") version "1.1.7"
     id("org.hibernate.orm") version "6.6.22.Final"
     id("org.graalvm.buildtools.native") version "0.10.6"
+    id("io.freefair.lombok") version "8.13.1"
     kotlin("jvm") version "2.2.0"
     kotlin("plugin.spring") version "2.2.0"
     kotlin("plugin.jpa") version "2.2.0"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -121,9 +121,4 @@ kotlin {
     }
 }
 
-// 특정 어노테이션에 대해 자동으로 open 키워드 추가
-allOpen {
-    annotation("jakarta.persistence.Entity") // 엔티티는 프록시로 대체될 수 있어야 함
-    annotation("jakarta.persistence.MappedSuperclass") //공통 부모, 상속 가능해야
-    annotation("jakarta.persistence.Embeddable") // 값 타입
-}
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,9 +84,19 @@ hibernate {
 }
 
 tasks.withType<JavaCompile> {
-    options.compilerArgs.add("-Xlint:unchecked")
-    options.compilerArgs.add("-Xlint:-unchecked") // AOT 생성 코드의 unchecked 경고 무시
     options.encoding = "UTF-8"
+}
+
+// 일반 Java 컴파일에서는 경고 활성화
+tasks.named("compileJava", JavaCompile::class) {
+    options.compilerArgs.add("-Xlint:unchecked")
+}
+
+// AOT 컴파일 태스크에서는 생성된 코드의 경고 완전 제거
+tasks.named("compileAotJava", JavaCompile::class) {
+    options.compilerArgs.addAll(listOf(
+        "-Xlint:none"  // 모든 경고 완전 제거
+    ))
 }
 
 tasks.withType<Test> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ import java.time.format.DateTimeFormatter
 
 plugins {
     java
-    id("org.springframework.boot") version "3.5.3"
+    id("org.springframework.boot") version "3.5.4"
     id("io.spring.dependency-management") version "1.1.7"
     id("org.hibernate.orm") version "6.6.18.Final"
     id("org.graalvm.buildtools.native") version "0.10.6"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
     kotlin("jvm") version "2.2.0"
     kotlin("plugin.spring") version "2.2.0"
     kotlin("plugin.jpa") version "2.2.0"
+    kotlin("plugin.lombok") version "2.2.0"
 }
 group = "dev.haja"
 var releaseVer = "v0.0.1"
@@ -120,5 +121,3 @@ kotlin {
         allWarningsAsErrors = true
     }
 }
-
-

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,11 +10,9 @@ plugins {
     id("io.spring.dependency-management") version "1.1.7"
     id("org.hibernate.orm") version "6.6.22.Final"
     id("org.graalvm.buildtools.native") version "0.10.6"
-    id("io.freefair.lombok") version "8.13.1"
     kotlin("jvm") version "2.2.0"
     kotlin("plugin.spring") version "2.2.0"
     kotlin("plugin.jpa") version "2.2.0"
-    kotlin("plugin.lombok") version "2.2.0"
 }
 group = "dev.haja"
 var releaseVer = "v0.0.1"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
     java
     id("org.springframework.boot") version "3.5.4"
     id("io.spring.dependency-management") version "1.1.7"
-    id("org.hibernate.orm") version "6.6.18.Final"
+    id("org.hibernate.orm") version "6.6.22.Final"
     id("org.graalvm.buildtools.native") version "0.10.6"
     kotlin("jvm") version "2.2.0"
     kotlin("plugin.spring") version "2.2.0"


### PR DESCRIPTION
close #24

```korean
## Sourcery 요약

플러그인 버전 업데이트, Java 컴파일러 린트 설정 개선, 오래된 allOpen 설정 제거 및 개발 가이드라인을 위한 CLAUDE.md 문서 파일 추가를 통해 빌드 구성을 업데이트했습니다.

개선 사항:
- Spring Boot 플러그인 버전을 3.5.4로, Hibernate 플러그인 버전을 6.6.22.Final로 올림
- compileJava에 unchecked 린트 설정 및 compileAotJava에서 모든 경고를 억제하도록 설정
- JPA 어노테이션용으로 더 이상 사용되지 않는 allOpen 플러그인 구성 제거

문서화:
- 빌드, 개발, 아키텍처 및 테스트 가이드라인이 포함된 CLAUDE.md 파일 추가
```

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update build configuration by bumping plugin versions, refining Java compiler lint settings, and remove outdated allOpen settings, and add a CLAUDE.md documentation file for development guidelines.

Enhancements:
- Bump Spring Boot plugin to 3.5.4 and Hibernate plugin to 6.6.22.Final
- Configure compileJava with unchecked lint and compileAotJava to suppress all warnings
- Remove deprecated allOpen plugin configuration for JPA annotations

Documentation:
- Add CLAUDE.md with build, development, architecture, and testing guidelines

</details>