### PR TITLE
feat/66-sm-260104

### DIFF
--- a/WARP.md
+++ b/WARP.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,6 +79,9 @@ dependencies {
     // starter 대신 core 모듈 직접 사용 (Spring Security를 사용하지 않으므로)
     testImplementation("org.springframework.boot:spring-boot-webmvc-test")   // @WebMvcTest
     testImplementation("org.springframework.boot:spring-boot-starter-data-jpa-test") // @DataJpaTest
+    // Spring Boot 4.0: RestTemplateBuilder가 restclient 모듈로 분리됨
+    // resttestclient가 restclient를 transitive 의존하지 않아 명시적 추가 필요
+    testImplementation("org.springframework.boot:spring-boot-restclient")
     testImplementation("org.springframework.boot:spring-boot-resttestclient") // TestRestTemplate, @AutoConfigureTestRestTemplate
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/gradle.properties
+++ b/gradle.properties
@@ -46,12 +46,12 @@ org.gradle.jvmargs=-Dfile.encoding=UTF-8 \
 # 2. 외부화된 버전 정보
 # - 외부화된 버전 정보 (Externalized Version Information)
 #   1) 언어 버전
-kotlinVersion=2.3.0-RC2
+kotlinVersion=2.3.0
 javaVersion=25
 #groovyVersion=4.0.15
 
 #   2) 프레임워크 버전
-springBootVersion=4.0.0
+springBootVersion=4.0.1
 dependencyManageVer = 1.1.7
 nativeBuildVersion = 0.11.3
 #springCloudVersion=2023.0.0
@@ -59,7 +59,7 @@ nativeBuildVersion = 0.11.3
 #   3) 라이브러리 버전
 #Jakarta Persistence API 3.2.0 호환성 (Hibernate 7.x 지원)
 jpaVersion =3.2.0
-hibernateVersion=7.1.8.Final
+hibernateVersion=7.2.0.Final
 mapstructVersion=1.6.3
 mapstructSpringVersion=1.1.3
 kspVersion=2.3.0
@@ -68,7 +68,7 @@ mockkVersion=1.14.6
 springMockKVersion=5.0.1
 #jacksonVersion=2.15.3
 #nettyVersion=4.1.100.Final
-sonarqubeVersion=7.1.0.6387
+sonarqubeVersion=7.2.2.6593
 # KAPT 설정
 kapt.include.compile.classpath=false
 kapt.incremental.apt=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-rc-2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-rc-3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-rc-2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
자동 생성된 PR입니다. 브랜치 feat/66-sm-260104 의 변경 사항을 기본 브랜치로 병합합니다.

## Summary by Sourcery

핵심 빌드 및 의존성 버전을 업데이트하고 Spring Boot 4.0 변경 사항에 맞게 테스트를 조정합니다.

Build:
- Kotlin을 2.3.0으로, Spring Boot를 4.0.1로, Hibernate를 7.2.0.Final로, SonarQube 플러그인을 7.2.2.6593으로, Gradle wrapper를 9.3.0-rc-3으로 상향 조정합니다.

Documentation:
- CLAUDE.md를 참조하는 포인터 파일 WARP.md를 추가합니다.

Tests:
- Spring Boot 4.0 기반 테스트에서 `RestTemplateBuilder`를 지원하기 위해 명시적인 `spring-boot-restclient` 테스트 의존성을 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update core build and dependency versions and adjust tests for Spring Boot 4.0 changes.

Build:
- Bump Kotlin to 2.3.0, Spring Boot to 4.0.1, Hibernate to 7.2.0.Final, SonarQube plugin to 7.2.2.6593, and Gradle wrapper to 9.3.0-rc-3.

Documentation:
- Add WARP.md pointer file referencing CLAUDE.md.

Tests:
- Add explicit spring-boot-restclient test dependency to support RestTemplateBuilder in Spring Boot 4.0-based tests.

</details>