### PR TITLE
⬆️ maintain: 의존성 업그레이드 및 Spring Boot 4.1.0 마이그레이션 (#69)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,8 +20,9 @@ plugins {
 val javaVersion = libs.versions.java.get()
 
 // 프로젝트 메타데이터(group은 gradle.properties의 group으로 자동 설정)
-// releaseVer만 version 문자열 조합에 사용하므로 delegation 유지
-val releaseVer: String by project
+// releaseVer만 version 문자열 조합에 사용.
+// Gradle 10에서 제거될 'by project' 위임 문법 대신 Provider API 사용
+val releaseVer: String = providers.gradleProperty("releaseVer").get()
 
 version =
     "$releaseVer-${LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"))}"
@@ -181,13 +182,8 @@ kapt {
     }
 }
 
-hibernate {
-    enhancement {
-        // Hibernate 7.x에서 deprecated
-        //  성능 최적화를 위해 비활성화
-        enableAssociationManagement = false
-    }
-}
+// Hibernate 7.x에서 association management enhancement가 deprecated 되었고,
+// 기본값이 비활성화(false)이므로 별도 설정 없이 기본값 사용 (deprecated 경고 제거)
 
 tasks.withType<JavaCompile> {
     options.encoding = "UTF-8"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,8 +66,13 @@ dependencies {
 
     // Test - Spring Boot 4.0: 모듈화된 테스트 스타터 사용
     // Spring Security를 사용하지 않으므로 security-test 제외
+    // Spring Boot 4.1: classic 테스트 스타터에 grpc-test가 편입됨.
+    // grpc-test의 spring.factories가 GrpcPortInfoApplicationContextInitializer를
+    // 무조건 등록 → GrpcServerStartedEvent(spring-grpc) 미존재로 컨텍스트 로딩 실패.
+    // gRPC를 사용하지 않으므로 grpc-test 제외
     testImplementation("org.springframework.boot:spring-boot-starter-test-classic") {
         exclude(group = "org.springframework.boot", module = "spring-boot-security-test")
+        exclude(group = "org.springframework.boot", module = "spring-boot-grpc-test")
     }
     // Spring Boot 4.0: 슬라이스 테스트를 위한 개별 테스트 모듈
     // starter 대신 core 모듈 직접 사용 (Spring Security를 사용하지 않으므로)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ kotlin = "2.4.0"
 java = "25"
 
 # 2) 프레임워크 / 빌드 플러그인
-springBoot = "4.0.6"
+springBoot = "4.0.7"
 dependencyManagement = "1.1.7"
 nativeBuild = "0.11.5"
 hibernate = "7.2.12.Final"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,10 +8,10 @@ kotlin = "2.4.0"
 java = "25"
 
 # 2) 프레임워크 / 빌드 플러그인
-springBoot = "4.0.7"
+springBoot = "4.0.6"
 dependencyManagement = "1.1.7"
-nativeBuild = "1.1.3"
-hibernate = "7.4.3.Final"
+nativeBuild = "0.11.5"
+hibernate = "7.2.12.Final"
 ksp = "2.3.0"
 
 # 3) 라이브러리

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 
 [versions]
 # 1) 언어
-kotlin = "2.4.0-RC"
+kotlin = "2.4.0"
 java = "25"
 
 # 2) 프레임워크 / 빌드 플러그인

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ kotest = "6.0.7"
 mockk = "1.14.11"
 springMockk = "5.0.1"
 archunit = "1.4.2"
-mockitoKotlin = "6.0.0"
+mockitoKotlin = "6.3.0"
 lombokMapstructBinding = "0.2.0"
 # CVE-2025-48924 보안 취약점 해결용 강제 버전
 commonsLang3 = "3.20.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ java = "25"
 springBoot = "4.0.6"
 dependencyManagement = "1.1.7"
 nativeBuild = "0.11.5"
-hibernate = "7.2.12.Final"
+hibernate = "7.4.3.Final"
 ksp = "2.3.0"
 
 # 3) 라이브러리

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ kotlin = "2.4.0"
 java = "25"
 
 # 2) 프레임워크 / 빌드 플러그인
-springBoot = "4.0.7"
+springBoot = "4.1.0"
 dependencyManagement = "1.1.7"
 nativeBuild = "1.1.3"
 hibernate = "7.4.3.Final"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ java = "25"
 # 2) 프레임워크 / 빌드 플러그인
 springBoot = "4.0.6"
 dependencyManagement = "1.1.7"
-nativeBuild = "0.11.5"
+nativeBuild = "1.1.3"
 hibernate = "7.4.3.Final"
 ksp = "2.3.9"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ kotlin = "2.4.0"
 java = "25"
 
 # 2) 프레임워크 / 빌드 플러그인
-springBoot = "4.0.6"
+springBoot = "4.0.7"
 dependencyManagement = "1.1.7"
 nativeBuild = "1.1.3"
 hibernate = "7.4.3.Final"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ springBoot = "4.0.6"
 dependencyManagement = "1.1.7"
 nativeBuild = "0.11.5"
 hibernate = "7.4.3.Final"
-ksp = "2.3.0"
+ksp = "2.3.9"
 
 # 3) 라이브러리
 # Jakarta Persistence API 3.2.0 호환성 (Hibernate 7.x 지원)
@@ -20,7 +20,7 @@ jpa = "3.2.0"
 mapstruct = "1.6.3"
 mapstructSpring = "1.1.3"
 kotest = "6.0.7"
-mockk = "1.14.9"
+mockk = "1.14.11"
 springMockk = "5.0.1"
 archunit = "1.4.1"
 mockitoKotlin = "6.0.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ mapstructSpring = "1.1.3"
 kotest = "6.0.7"
 mockk = "1.14.11"
 springMockk = "5.0.1"
-archunit = "1.4.1"
+archunit = "1.4.2"
 mockitoKotlin = "6.0.0"
 lombokMapstructBinding = "0.2.0"
 # CVE-2025-48924 보안 취약점 해결용 강제 버전

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,8 +15,6 @@ hibernate = "7.4.3.Final"
 ksp = "2.3.9"
 
 # 3) 라이브러리
-# Jakarta Persistence API 3.2.0 호환성 (Hibernate 7.x 지원)
-jpa = "3.2.0"
 mapstruct = "1.6.3"
 mapstructSpring = "1.1.3"
 kotest = "6.0.7"
@@ -32,8 +30,8 @@ commonsLang3 = "3.20.0"
 # Spring Boot BOM (platform)
 spring-boot-dependencies = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "springBoot" }
 
-# JPA
-jakarta-persistence-api = { module = "jakarta.persistence:jakarta.persistence-api", version.ref = "jpa" }
+# JPA (버전은 Spring Boot BOM이 관리 - 기본 Jakarta Persistence 3.2)
+jakarta-persistence-api = { module = "jakarta.persistence:jakarta.persistence-api" }
 
 # MapStruct
 mapstruct = { module = "org.mapstruct:mapstruct", version.ref = "mapstruct" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,8 +10,8 @@ java = "25"
 # 2) 프레임워크 / 빌드 플러그인
 springBoot = "4.0.7"
 dependencyManagement = "1.1.7"
-nativeBuild = "0.11.5"
-hibernate = "7.2.12.Final"
+nativeBuild = "1.1.3"
+hibernate = "7.4.3.Final"
 ksp = "2.3.0"
 
 # 3) 라이브러리

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,2 @@
 [tools]
-java = "oracle-graalvm-25.0.1"
+java = "oracle-graalvm-25.0.3"


### PR DESCRIPTION
## 개요

Issue #69 유지보수 작업. 주요 의존성·빌드 도구를 최신 버전으로 업그레이드하고, Spring Boot 4.1.0 마이그레이션 과정에서 발생한 테스트 컨텍스트 로딩 실패를 해결했습니다.

## 주요 변경 사항

### ⬆️ 의존성 업그레이드
| 항목 | 이전 | 이후 |
| --- | --- | --- |
| Spring Boot | 4.0.6 | **4.1.0** |
| Kotlin | 2.4.0-RC | **2.4.0** |
| Hibernate | 7.2.12.Final | **7.4.3.Final** |
| KSP | 2.3.0 | **2.3.9** |
| Native Build | 0.11.5 | **1.1.3** |
| MockK | 1.14.9 | **1.14.11** |
| ArchUnit | 1.4.1 | **1.4.2** |
| mockito-kotlin | 6.0.0 | **6.3.0** |

### 🔧 빌드 도구 업그레이드
- Gradle 9.5.1 → **9.6.1**
- GraalVM 25.0.1 → **25.0.3** (`mise.toml`)

### 🐛 Spring Boot 4.1.0 마이그레이션 이슈 해결
- **문제**: 테스트 실행 시 `ClassNotFoundException: org.springframework.grpc.server.lifecycle.GrpcServerStartedEvent`로 컨텍스트 로딩 실패
- **원인**: 4.1.0부터 `spring-boot-starter-test-classic`에 `spring-boot-grpc-test`가 편입됨. 해당 모듈의 `spring.factories`가 `GrpcPortInfoApplicationContextInitializer`를 조건 가드 없이 무조건 등록 → `spring-grpc` 미존재로 실패
- **해결**: 기존 `spring-boot-security-test` 제외와 동일하게, 사용하지 않는 `spring-boot-grpc-test` 모듈 제외

### 🧹 기타 정리
- JPA 버전 명시 제거 → Spring Boot BOM 기본 버전(Jakarta Persistence 3.2) 사용
- Gradle 10에서 제거될 `by project` 위임 문법 → Provider API(`providers.gradleProperty`)로 교체
- Hibernate 7.x에서 deprecated된 association management enhancement 설정 제거 (기본값 사용)

## 테스트
- `./gradlew build` 전체 빌드 통과

Closes #69

## Summary by Sourcery

핵심 종속성과 빌드 도구를 업그레이드하여 Spring Boot 4.1.0을 지원하고, 관련된 테스트 컨텍스트 로딩 문제를 해결합니다.

Enhancements:
- Kotlin, Spring Boot, Hibernate, KSP 및 주요 테스트 라이브러리를 최신 호환 버전으로 정렬하고, Jakarta Persistence에 대해서는 Spring Boot BOM에 의존하도록 합니다.
- 사용이 중단된 Hibernate association management enhancement 설정을 제거하고 기본 동작을 사용합니다.

Build:
- Gradle wrapper를 9.6.1로 업그레이드하고, 릴리스 버전 관리를 Gradle Provider API로 전환합니다.
- mise에서 사용하는 GraalVM Java 런타임 버전을 oracle-graalvm-25.0.3으로 업데이트합니다.

Tests:
- Spring Boot 4.1.0 환경에서 gRPC 관련 컨텍스트 로딩 실패를 방지하기 위해, 고전(Spring Boot classic) Spring Boot test starter에서 `spring-boot-grpc-test` 모듈을 제외합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade core dependencies and build tools to support Spring Boot 4.1.0 and resolve related test context loading issues.

Enhancements:
- Align Kotlin, Spring Boot, Hibernate, KSP, and key testing libraries to their latest compatible versions and rely on the Spring Boot BOM for Jakarta Persistence.
- Remove deprecated Hibernate association management enhancement configuration and use the default behavior.

Build:
- Upgrade Gradle wrapper to 9.6.1 and switch release version handling to the Gradle Provider API.
- Update GraalVM Java runtime version used by mise to oracle-graalvm-25.0.3.

Tests:
- Exclude the spring-boot-grpc-test module from the classic Spring Boot test starter to prevent gRPC-related context loading failures under Spring Boot 4.1.0.

</details>