### PR TITLE
⬆️ maintain: Kotlin 2.4 업그레이드 (#71)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -234,8 +234,8 @@ kotlin {
         freeCompilerArgs.add("-Xannotation-default-target=param-property")
         allWarningsAsErrors = true
         jvmTarget.set(JvmTarget.fromTarget(javaVersion))
-        languageVersion.set(KotlinVersion.KOTLIN_2_3)
-        apiVersion.set(KotlinVersion.KOTLIN_2_3)
+        languageVersion.set(KotlinVersion.KOTLIN_2_4)
+        apiVersion.set(KotlinVersion.KOTLIN_2_4)
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -231,7 +231,6 @@ kotlin {
     compilerOptions {
         freeCompilerArgs.add("-Xjsr305=strict")             //  JSR-305 애노테이션의 null 안정성 어노테이션을 엄격
         freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn") // 실험적 API등 API를 사용할 때 해당 옵트인 어노테이션 사용을 허용
-        freeCompilerArgs.add("-Xannotation-default-target=param-property")
         allWarningsAsErrors = true
         jvmTarget.set(JvmTarget.fromTarget(javaVersion))
         languageVersion.set(KotlinVersion.KOTLIN_2_4)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,4 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
@@ -233,8 +232,10 @@ kotlin {
         freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn") // 실험적 API등 API를 사용할 때 해당 옵트인 어노테이션 사용을 허용
         allWarningsAsErrors = true
         jvmTarget.set(JvmTarget.fromTarget(javaVersion))
-        languageVersion.set(KotlinVersion.KOTLIN_2_4)
-        apiVersion.set(KotlinVersion.KOTLIN_2_4)
+        // languageVersion / apiVersion 미지정 → 플러그인(Kotlin Version Catalog) 기본값 자동 추종.
+        // 애플리케이션이라 apiVersion 고정이 불필요하고, 컴파일러 버전이 곧 단일 언어 표준.
+        // 명시하면 컴파일러 버전을 미러링만 하면서 업그레이드마다 lockstep bump가 필요하고,
+        // 누락 시 allWarningsAsErrors와 맞물려 deprecated-language-version 경고가 빌드 실패로 이어짐.
     }
 }
 


### PR DESCRIPTION
## 개요
Kotlin 언어 버전을 2.4로 업그레이드하고, 업그레이드 이후 발생한 빌드 실패를 수정합니다.

Closes #71

## 변경 사항
### 1. Kotlin 2.4로 업그레이드 (470c48d)
- Version Catalog의 Kotlin 버전 및 `languageVersion`/`apiVersion`을 2.4로 상향.

### 2. Kotlin 2.4 마이그레이션 후 빌드 실패 수정 (fc25ecb)
- **문제**: `clean build` 시 `-Xannotation-default-target=param-property` 인자가 language version 2.4에서 redundant 경고를 발생 → `allWarningsAsErrors = true`(-Werror)로 에러 승격되어 `:kaptGenerateStubsKotlin`에서 빌드 중단.
- **원인**: 해당 인자는 Kotlin 2.3에서 2.4의 기본 동작을 미리 적용하기 위한 옵션. 2.4에서 기본값이 되어 불필요해짐.
- **조치**: redundant해진 인자 제거. Kotlin 2.4부터 param-property가 기본값이므로 동작은 동일하게 유지.

## 검증
- `./gradlew clean build --no-build-cache --warning-mode all` → BUILD SUCCESSFUL, 전체 테스트 통과.

## 참고: 후속 과제 (별도 이슈 권장)
`--warning-mode all` 실행 시 아래 deprecation이 관찰됨:
> Using a Project object as a dependency notation has been deprecated. (Gradle 10에서 에러 예정)

스택트레이스 분석 결과 **프로젝트 빌드 스크립트가 아닌 GraalVM Native Build Tools 플러그인(`org.graalvm.buildtools.native` 1.1.3) 내부**(`NativeImagePlugin.createNativeConfigurations`)에서 발생. 프로젝트 코드로는 수정 불가하며, 플러그인 상위 버전 대기 또는 업스트림 대응이 필요하여 이번 PR 범위에서 제외.

## Summary by Sourcery

Build:
- Kotlin 컴파일러 설정을 업데이트하여 더 이상 language/apiVersion을 고정하지 않고, 사용되지 않는 `annotation-default-target` 옵션을 제거합니다. 대신 버전 카탈로그의 Kotlin 2.4 기본값을 사용하도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Update Kotlin compiler configuration to no longer pin language/apiVersion and remove obsolete annotation-default-target option, relying on the Version Catalog’s Kotlin 2.4 defaults instead.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Kotlin 컴파일러 설정을 업데이트하여 더 이상 language/apiVersion을 고정하지 않고, 사용되지 않는 `annotation-default-target` 옵션을 제거합니다. 대신 버전 카탈로그의 Kotlin 2.4 기본값을 사용하도록 합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Update Kotlin compiler configuration to no longer pin language/apiVersion and remove obsolete annotation-default-target option, relying on the Version Catalog’s Kotlin 2.4 defaults instead.

</details>

</details>